### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+.__pycache__/*


### PR DESCRIPTION
funker det?
This pull request includes a small change to the `.gitattributes` file. The change ensures that all files in the `__pycache__` directory are ignored. 

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR3): Added a rule to ignore all files in the `__pycache__` directory.